### PR TITLE
Fix code scanning alert no. 9: Dependency download using unencrypted communication channel

### DIFF
--- a/vendor/cache/activeldap-08d8f65f35f6/Gemfile
+++ b/vendor/cache/activeldap-08d8f65f35f6/Gemfile
@@ -1,6 +1,6 @@
 # -*- ruby -*-
 
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 


### PR DESCRIPTION
Fixes [https://github.com/GrantBirki/ldap-api/security/code-scanning/9](https://github.com/GrantBirki/ldap-api/security/code-scanning/9)

To fix the problem, we need to change the protocol of the source URL from HTTP to HTTPS. This ensures that the communication channel used to download dependencies is encrypted, protecting against potential MITM attacks. The change is straightforward and involves modifying the URL in the `Gemfile`.

Specifically, we need to update line 3 in the file `vendor/cache/activeldap-08d8f65f35f6/Gemfile` to use `https://rubygems.org` instead of `http://rubygems.org`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
